### PR TITLE
address lines_longer_than_80_chars lints

### DIFF
--- a/example/arg_parser/pubspec.yaml
+++ b/example/arg_parser/pubspec.yaml
@@ -6,8 +6,10 @@ name: arg_parser_example
 version: 1.0.0
 description: An example of using ArgParser
 publish_to: 'none'
+
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: ^3.0.0
+
 dependencies:
   args:
     path: ../..

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -119,9 +119,11 @@ class ArgParser {
   ///
   /// If [hide] is `true`, this option won't be included in [usage].
   ///
-  /// If [hideNegatedUsage] is `true`, the fact that this flag can be negated will
-  /// not be documented in [usage].
-  /// It is an error for [hideNegatedUsage] to be `true` if [negatable] is `false`.
+  /// If [hideNegatedUsage] is `true`, the fact that this flag can be negated
+  /// will not be documented in [usage].
+  ///
+  /// It is an error for [hideNegatedUsage] to be `true` if [negatable] is
+  /// `false`.
   ///
   /// If [aliases] is provided, these are used as aliases for [name]. These
   /// aliases will not appear as keys in the [options] map.
@@ -315,8 +317,7 @@ class ArgParser {
 
     if (!negatable && hideNegatedUsage) {
       throw ArgumentError(
-        'The option $name cannot have `hideNegatedUsage` without being negatable.',
-      );
+          'The option $name can only use hideNegatedUsage if it is negatable.');
     }
 
     var option = newOption(name, abbr, help, valueHelp, allowed, allowedHelp,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: args
 version: 2.6.0
 description: >-
-  Library for defining parsers for parsing raw command-line arguments into a set
-  of options and values using GNU and POSIX style options.
+  Library for defining parsers for parsing raw command-line arguments into a
+  set of options and values using GNU and POSIX style options.
 repository: https://github.com/dart-lang/args
 
 topics:


### PR DESCRIPTION
Address 3 diagnostics related to the `lines_longer_than_80_chars` lint as well as a few nits.

@sigurdm, if we merge this into your PR, it should then pass the CI checks (we're in the process of transferring the args repo to the core monorepo, so want to close out active PRs).
